### PR TITLE
Reduce lock contention

### DIFF
--- a/VoxelWorld/MainThreadWork.cs
+++ b/VoxelWorld/MainThreadWork.cs
@@ -185,6 +185,28 @@ namespace VoxelWorld
             return DrawCommands.Count;
         }
 
+        public bool Reset()
+        {
+            lock (Lock)
+            {
+                if (TransferToBuffers.Count > 0 || DrawCommands.Count > 0)
+                {
+                    return false;
+                }
+
+                TransferToBuffers.Clear();
+                DrawCommands.Clear();
+
+                VerticesAvailable = VERTEX_BUFFER_SIZE;
+                IndicesAvailable = INDICE_BUFFER_SIZE;
+                CommandsAvailable = COMMAND_BUFFER_SIZE;
+                FirstAvailableVertexIndex = 0;
+                FirstAvailableIndiceIndex = 0;
+
+                return true;
+            }
+        }
+
         public void Dispose()
         {
             Vao.Dispose();
@@ -279,8 +301,7 @@ namespace VoxelWorld
                 {
                     if (GridDrawBuffers[i].CommandCount() == 0)
                     {
-                        GridDrawBuffers[i].Dispose();
-                        GridDrawBuffers.RemoveAt(i);
+                        GridDrawBuffers[i].Reset();
                     }
                 }
 

--- a/VoxelWorld/MainThreadWork.cs
+++ b/VoxelWorld/MainThreadWork.cs
@@ -26,6 +26,7 @@ namespace VoxelWorld
             }
         }
 
+
         private readonly List<CommandPair> TransferToBuffers = new List<CommandPair>();
         private readonly Dictionary<VoxelGridInfo, DrawElementsIndirectCommand> DrawCommands = new Dictionary<VoxelGridInfo, DrawElementsIndirectCommand>();
         private const int VERTEX_BUFFER_SIZE = 20_000;

--- a/VoxelWorld/MainThreadWork.cs
+++ b/VoxelWorld/MainThreadWork.cs
@@ -36,7 +36,6 @@ namespace VoxelWorld
         private int CommandsAvailable = COMMAND_BUFFER_SIZE;
         private int FirstAvailableVertexIndex = 0;
         private int FirstAvailableIndiceIndex = 0;
-        private readonly object Lock = new object();
         private bool CommandsChangeSinceLastPrepareDraw = false;
 
         private readonly VBO<Vector3> VertexBuffer;
@@ -65,118 +64,106 @@ namespace VoxelWorld
 
         public bool TryAddGeometry(VoxelGridInfo grid, GeometryData geometry)
         {
-            lock (Lock)
+            if (VerticesAvailable >= geometry.Vertices.Length &&
+                IndicesAvailable >= geometry.Indices.Length &&
+                CommandsAvailable >= 1)
             {
-                if (VerticesAvailable >= geometry.Vertices.Length &&
-                    IndicesAvailable >= geometry.Indices.Length &&
-                    CommandsAvailable >= 1)
-                {
-                    VerticesAvailable -= geometry.Vertices.Length;
-                    IndicesAvailable -= geometry.Indices.Length;
-                    CommandsAvailable--;
-                    TransferToBuffers.Add(new CommandPair(grid, geometry));
-                    return true;
-                }
-                return false;
+                VerticesAvailable -= geometry.Vertices.Length;
+                IndicesAvailable -= geometry.Indices.Length;
+                CommandsAvailable--;
+                TransferToBuffers.Add(new CommandPair(grid, geometry));
+                return true;
             }
+            return false;
         }
 
         public bool RemoveGeometry(VoxelGridInfo grid)
         {
-            lock (Lock)
+            if (!DrawCommands.Remove(grid))
             {
-                if (!DrawCommands.Remove(grid))
+                int removed = TransferToBuffers.RemoveAll(x => x.Grid == grid);
+                if (removed > 1)
                 {
-                    int removed = TransferToBuffers.RemoveAll(x => x.Grid == grid);
-                    if (removed > 1)
-                    {
-                        throw new Exception();
-                    }
-                    return removed == 1;
+                    throw new Exception();
                 }
-                else
-                {
-                    CommandsChangeSinceLastPrepareDraw = true;
-                    return true;
-                }
+                return removed == 1;
+            }
+            else
+            {
+                CommandsChangeSinceLastPrepareDraw = true;
+                return true;
             }
         }
 
         public void PrepareDraw()
         {
-            lock (Lock)
+            if (TransferToBuffers.Count > 0)
             {
-                if (TransferToBuffers.Count > 0)
+                int vertices = 0;
+                int indices = 0;
+                for (int i = 0; i < TransferToBuffers.Count; i++)
                 {
-                    int vertices = 0;
-                    int indices = 0;
-                    for (int i = 0; i < TransferToBuffers.Count; i++)
-                    {
-                        vertices += TransferToBuffers[i].Geom.Vertices.Length;
-                        indices += TransferToBuffers[i].Geom.Indices.Length;
-                    }
-
-                    Vector3[] verticesTemp = new Vector3[vertices];
-                    uint[] indicesTemp = new uint[indices];
-
-                    {
-                        Span<Vector3> availableSpace = verticesTemp.AsSpan();
-                        for (int i = 0; i < TransferToBuffers.Count; i++)
-                        {
-                            TransferToBuffers[i].Geom.Vertices.CopyTo(availableSpace);
-                            availableSpace = availableSpace.Slice(TransferToBuffers[i].Geom.Vertices.Length);
-                        }
-                        VertexBuffer.BufferSubData(verticesTemp, verticesTemp.Length * Marshal.SizeOf<Vector3>(), FirstAvailableVertexIndex * Marshal.SizeOf<Vector3>());
-                    }
-                    {
-                        Span<Vector3> availableSpace = verticesTemp.AsSpan();
-                        for (int i = 0; i < TransferToBuffers.Count; i++)
-                        {
-                            TransferToBuffers[i].Geom.Normals.CopyTo(availableSpace);
-                            availableSpace = availableSpace.Slice(TransferToBuffers[i].Geom.Normals.Length);
-                        }
-                        NormalBuffer.BufferSubData(verticesTemp, verticesTemp.Length * Marshal.SizeOf<Vector3>(), FirstAvailableVertexIndex * Marshal.SizeOf<Vector3>());
-                    }
-
-                    {
-                        Span<uint> availableSpace = indicesTemp.AsSpan();
-                        for (int i = 0; i < TransferToBuffers.Count; i++)
-                        {
-                            TransferToBuffers[i].Geom.Indices.CopyTo(availableSpace);
-                            availableSpace = availableSpace.Slice(TransferToBuffers[i].Geom.Indices.Length);
-                        }
-                        IndiceBuffer.BufferSubData(indicesTemp, indicesTemp.Length * Marshal.SizeOf<uint>(), FirstAvailableIndiceIndex * Marshal.SizeOf<uint>());
-                    }
-
-                    for (int i = 0; i < TransferToBuffers.Count; i++)
-                    {
-                        GeometryData geom = TransferToBuffers[i].Geom;
-                        DrawCommands.Add(TransferToBuffers[i].Grid, new DrawElementsIndirectCommand(geom.Indices.Length, 1, FirstAvailableIndiceIndex, FirstAvailableVertexIndex, 0));
-                        FirstAvailableVertexIndex += geom.Vertices.Length;
-                        FirstAvailableIndiceIndex += geom.Indices.Length;
-                    }
-
-                    TransferToBuffers.Clear();
-                    CommandsChangeSinceLastPrepareDraw = true;
+                    vertices += TransferToBuffers[i].Geom.Vertices.Length;
+                    indices += TransferToBuffers[i].Geom.Indices.Length;
                 }
 
-                if (DrawCommands.Count > 0 && CommandsChangeSinceLastPrepareDraw)
+                Vector3[] verticesTemp = new Vector3[vertices];
+                uint[] indicesTemp = new uint[indices];
+
                 {
-                    DrawElementsIndirectCommand[] commands = DrawCommands.Values.ToArray();
-                    CommandBuffer.BufferSubData(commands);
-                    CommandsChangeSinceLastPrepareDraw = false;
+                    Span<Vector3> availableSpace = verticesTemp.AsSpan();
+                    for (int i = 0; i < TransferToBuffers.Count; i++)
+                    {
+                        TransferToBuffers[i].Geom.Vertices.CopyTo(availableSpace);
+                        availableSpace = availableSpace.Slice(TransferToBuffers[i].Geom.Vertices.Length);
+                    }
+                    VertexBuffer.BufferSubData(verticesTemp, verticesTemp.Length * Marshal.SizeOf<Vector3>(), FirstAvailableVertexIndex * Marshal.SizeOf<Vector3>());
                 }
+                {
+                    Span<Vector3> availableSpace = verticesTemp.AsSpan();
+                    for (int i = 0; i < TransferToBuffers.Count; i++)
+                    {
+                        TransferToBuffers[i].Geom.Normals.CopyTo(availableSpace);
+                        availableSpace = availableSpace.Slice(TransferToBuffers[i].Geom.Normals.Length);
+                    }
+                    NormalBuffer.BufferSubData(verticesTemp, verticesTemp.Length * Marshal.SizeOf<Vector3>(), FirstAvailableVertexIndex * Marshal.SizeOf<Vector3>());
+                }
+
+                {
+                    Span<uint> availableSpace = indicesTemp.AsSpan();
+                    for (int i = 0; i < TransferToBuffers.Count; i++)
+                    {
+                        TransferToBuffers[i].Geom.Indices.CopyTo(availableSpace);
+                        availableSpace = availableSpace.Slice(TransferToBuffers[i].Geom.Indices.Length);
+                    }
+                    IndiceBuffer.BufferSubData(indicesTemp, indicesTemp.Length * Marshal.SizeOf<uint>(), FirstAvailableIndiceIndex * Marshal.SizeOf<uint>());
+                }
+
+                for (int i = 0; i < TransferToBuffers.Count; i++)
+                {
+                    GeometryData geom = TransferToBuffers[i].Geom;
+                    DrawCommands.Add(TransferToBuffers[i].Grid, new DrawElementsIndirectCommand(geom.Indices.Length, 1, FirstAvailableIndiceIndex, FirstAvailableVertexIndex, 0));
+                    FirstAvailableVertexIndex += geom.Vertices.Length;
+                    FirstAvailableIndiceIndex += geom.Indices.Length;
+                }
+
+                TransferToBuffers.Clear();
+                CommandsChangeSinceLastPrepareDraw = true;
+            }
+
+            if (DrawCommands.Count > 0 && CommandsChangeSinceLastPrepareDraw)
+            {
+                DrawElementsIndirectCommand[] commands = DrawCommands.Values.ToArray();
+                CommandBuffer.BufferSubData(commands);
+                CommandsChangeSinceLastPrepareDraw = false;
             }
         }
 
         public void Draw()
         {
-            lock (Lock)
+            if (DrawCommands.Count > 0)
             {
-                if (DrawCommands.Count > 0)
-                {
-                    Vao.MultiDrawElementsIndirect(CommandBuffer, DrawCommands.Count);
-                }
+                Vao.MultiDrawElementsIndirect(CommandBuffer, DrawCommands.Count);
             }
         }
 
@@ -187,24 +174,21 @@ namespace VoxelWorld
 
         public bool Reset()
         {
-            lock (Lock)
+            if (TransferToBuffers.Count > 0 || DrawCommands.Count > 0)
             {
-                if (TransferToBuffers.Count > 0 || DrawCommands.Count > 0)
-                {
-                    return false;
-                }
-
-                TransferToBuffers.Clear();
-                DrawCommands.Clear();
-
-                VerticesAvailable = VERTEX_BUFFER_SIZE;
-                IndicesAvailable = INDICE_BUFFER_SIZE;
-                CommandsAvailable = COMMAND_BUFFER_SIZE;
-                FirstAvailableVertexIndex = 0;
-                FirstAvailableIndiceIndex = 0;
-
-                return true;
+                return false;
             }
+
+            TransferToBuffers.Clear();
+            DrawCommands.Clear();
+
+            VerticesAvailable = VERTEX_BUFFER_SIZE;
+            IndicesAvailable = INDICE_BUFFER_SIZE;
+            CommandsAvailable = COMMAND_BUFFER_SIZE;
+            FirstAvailableVertexIndex = 0;
+            FirstAvailableIndiceIndex = 0;
+
+            return true;
         }
 
         public void Dispose()
@@ -215,98 +199,127 @@ namespace VoxelWorld
 
     internal static class MainThreadWork
     {
+        private enum CmdType
+        {
+            Add,
+            Remove
+        }
+
+        private readonly struct Command
+        {
+            public readonly VoxelGridInfo Grid;
+            public readonly GeometryData GeoData;
+            public readonly CmdType CType;
+
+            public Command(CmdType cmd, VoxelGridInfo grid, GeometryData data)
+            {
+                this.Grid = grid;
+                this.GeoData = data;
+                this.CType = cmd;
+            }
+        }
+
+        private static ConcurrentQueue<Command> Commands = new ConcurrentQueue<Command>();
+        private static ConcurrentQueue<Command> CommandSwitchout = new ConcurrentQueue<Command>();
+
         private static readonly List<IndirectDraw> GridDrawBuffers = new List<IndirectDraw>();
-        private static readonly List<(VoxelGridInfo grid, GeometryData geometry)> UnallocatedGridGeometry = new List<(VoxelGridInfo grid, GeometryData geometry)>();
 
 
         public static void MakeGridDrawable(VoxelGridInfo grid, GeometryData geometry)
         {
-            lock (GridDrawBuffers)
-            {
-                for (int i = 0; i < GridDrawBuffers.Count; i++)
-                {
-                    if (GridDrawBuffers[i].TryAddGeometry(grid, geometry))
-                    {
-                        return;
-                    }
-                }
-
-                UnallocatedGridGeometry.Add((grid, geometry));
-            }
+            Commands.Enqueue(new Command(CmdType.Add, grid, geometry));
         }
 
         public static void RemoveDrawableGrid(VoxelGridInfo grid)
         {
-            lock (GridDrawBuffers)
-            {
-                int removed = UnallocatedGridGeometry.RemoveAll(x => x.grid == grid);
-                if (removed > 1)
-                {
-                    throw new Exception();
-                }
-                else if (removed == 1)
-                {
-                    return;
-                }
-
-                for (int i = 0; i < GridDrawBuffers.Count; i++)
-                {
-                    if (GridDrawBuffers[i].RemoveGeometry(grid))
-                    {
-                        return;
-                    }
-                }
-
-                throw new Exception("Failed to remove grid");
-            }
+            Commands.Enqueue(new Command(CmdType.Remove, grid, new GeometryData()));
         }
 
         public static void DrawGrids()
         {
-            lock (GridDrawBuffers)
-            {
-                if (UnallocatedGridGeometry.Count > 0)
-                {
-                    int index = UnallocatedGridGeometry.Count - 1;
-                    while (index >= 0)
-                    {
-                        IndirectDraw draw = new IndirectDraw();
+            //switch queues so items stops being added to the queue
+            //we willwork on now
+            var cmds = Interlocked.Exchange(ref Commands, CommandSwitchout);
+            CommandSwitchout = cmds;
 
-                        while (draw.TryAddGeometry(UnallocatedGridGeometry[index].grid, UnallocatedGridGeometry[index].geometry))
+            int indexFirstBufferNotFull = 0;
+            while (!cmds.IsEmpty)
+            {
+                Command cmd;
+                if (!cmds.TryDequeue(out cmd))
+                {
+                    throw new Exception("Expected to dequeue a command but no command was found.");
+                }
+
+                if (cmd.CType == CmdType.Add)
+                {
+                    bool allocatedGrid = false;
+                    while (!allocatedGrid)
+                    {
+                        for (int i = indexFirstBufferNotFull; i < GridDrawBuffers.Count; i++)
                         {
-                            index--;
-                            if (index < 0)
+                            if (!GridDrawBuffers[i].TryAddGeometry(cmd.Grid, cmd.GeoData))
                             {
+                                if (i == indexFirstBufferNotFull)
+                                {
+                                    i++;
+                                }
+                            }
+                            else
+                            {
+                                allocatedGrid = true;
                                 break;
                             }
                         }
 
-                        GridDrawBuffers.Add(draw);
+                        if (!allocatedGrid)
+                        {
+                            GridDrawBuffers.Add(new IndirectDraw());
+                        }
                     }
-
-                    UnallocatedGridGeometry.Clear();
                 }
-
-                for (int i = 0; i < GridDrawBuffers.Count; i++)
+                else if (cmd.CType == CmdType.Remove)
                 {
-                    GridDrawBuffers[i].PrepareDraw();
-                }
-
-                for (int i = 0; i < GridDrawBuffers.Count; i++)
-                {
-                    GridDrawBuffers[i].Draw();
-                }
-
-                for (int i = GridDrawBuffers.Count - 1; i >= 0; i--)
-                {
-                    if (GridDrawBuffers[i].CommandCount() == 0)
+                    bool removedGrid = false;
+                    for (int i = 0; i < GridDrawBuffers.Count; i++)
                     {
-                        GridDrawBuffers[i].Reset();
+                        if (GridDrawBuffers[i].RemoveGeometry(cmd.Grid))
+                        {
+                            removedGrid = true;
+                            break;
+                        }
+                    }
+
+                    if (!removedGrid)
+                    {
+                        throw new Exception("Failed to find and remove a grid.");
                     }
                 }
-
-                //Console.WriteLine(GridDrawBuffers.Count);
+                else
+                {
+                    throw new Exception($"Unknown enum value: {cmd.CType}");
+                }
             }
+
+            for (int i = 0; i < GridDrawBuffers.Count; i++)
+            {
+                GridDrawBuffers[i].PrepareDraw();
+            }
+
+            for (int i = 0; i < GridDrawBuffers.Count; i++)
+            {
+                GridDrawBuffers[i].Draw();
+            }
+
+            for (int i = GridDrawBuffers.Count - 1; i >= 0; i--)
+            {
+                if (GridDrawBuffers[i].CommandCount() == 0)
+                {
+                    GridDrawBuffers[i].Reset();
+                }
+            }
+
+            Console.WriteLine(GridDrawBuffers.Count);
         }
     }
 }

--- a/VoxelWorld/VoxelHierarchy.cs
+++ b/VoxelWorld/VoxelHierarchy.cs
@@ -101,7 +101,7 @@ namespace VoxelWorld
             Vector3 c = model * cameraPos;
 
             float resolution = (VoxelSize * 100.0f) / (a - c).Length();
-            return resolution < 0.7f;
+            return resolution < 0.3f;
         }
 
         private void QueueGridGen(int index, Matrix4 model_rot, Vector3 lookDir)


### PR DESCRIPTION
Instead of each thread having to add/remove a grid, they now just add a
commands to a concurrentqueue. The main thread will then handle
adding/remove grids from the buffers. That makes it possible for
multiple threads to add/remove grids at the same time as each action
doesn't change the state. IndirectDraw class also doesn't need
synchorinzation anymore as only the main thread interacts with ti